### PR TITLE
feat(trading-squad): accessibility polish and live analyst completion note

### DIFF
--- a/agents/trading-squad/docs/IMPROVEMENT-PLAN.md
+++ b/agents/trading-squad/docs/IMPROVEMENT-PLAN.md
@@ -36,8 +36,12 @@ Legend: [ ] not started, [~] in progress, [x] done
 - [x] Optional tool-call hooks (decision: de-scoped)
   - Deep per-tool instrumentation (durations, arguments, etc.) was evaluated and intentionally deferred
   - Rationale: Limited end-user value vs. complexity; avoids UI noise and maintenance overhead
-- [ ] Accessibility polish
-  - Add ARIA labels and ensure high-contrast for agent status buttons in `render_agent_button()`
+- [x] Accessibility polish
+  - Added descriptive `help` strings in `render_agent_button()` for SR users
+  - High-contrast, keyboard-visible focus rings for primary/secondary buttons
+  - Reduced visual weight of non-running (secondary) buttons; smaller font and tighter padding
+  - Increased team expander title size/weight for clear hierarchy
+  - Pending state now shows "- Waiting" on sub-agent buttons
 
 ### 3.3 UI Optimization Plan (Integrated Excerpts)
 
@@ -99,6 +103,10 @@ Note: We will only take items from the optimization plan that do not risk breaki
   - Simplified to lifecycle-only logs to avoid duplication with Live Analysis Feed
   - Removed noisy mirrors, Finnhub and chunk-level logs; reduced maintenance surface
   - Decision: deeper instrumentation de-scoped; feature closed as "minimal and non-invasive"
+
+- 2025-09-06 10:13: Accessibility + progress note (merged to feature branch)
+  - Accessibility polish complete: descriptive tooltips for status buttons; high-contrast focus states; subdued secondary buttons; increased expander header size; pending shows "- Waiting"
+  - Added dynamic analysts completion note next to "Analysis in Progress" header that updates live (e.g., `2/12 analysts completed`)
 
 ## 8) Links
 


### PR DESCRIPTION
This PR implements accessibility and small UX improvements for the Trading Squad Streamlit UI.

Summary of changes
- Accessibility polish in `agents/trading-squad/app/trading_agents_streamlit.py`:
  - Descriptive help text for agent status buttons in `render_agent_button()`
  - High-contrast, keyboard-visible focus states for primary/secondary buttons
  - Subtler secondary buttons (transparent border, smaller font, tighter padding)
  - Team expander titles increased in size/weight to ensure clear hierarchy
  - Pending state shows “- Waiting” for sub-agent buttons
- Live completion note next to the header:
  - Added dynamic “(X/Y analysts completed)” via `get_analyst_progress_counts()` and `render_progress_header()`
  - Updates immediately on any `update_agent_status()` call and each streaming tick
- Plan doc update:
  - `agents/trading-squad/docs/IMPROVEMENT-PLAN.md` marks Accessibility polish done and logs today’s work

Validation (Smoke Test – Section 6)
- Ran the app via main entry: `agents/trading-squad/app/trading_agents_streamlit.py`
- Default analysts, yesterday’s date, NVDA
- Verified streaming, status transitions, and incremental report updates
- Verified exports: Full Report (md), Execution Log (jsonl), Quick Summary toggle
- Visuals consistent; no layout regressions

References
- Plan: `agents/trading-squad/docs/IMPROVEMENT-PLAN.md` (Section 3.2)
- Main UI: `agents/trading-squad/app/trading_agents_streamlit.py`
